### PR TITLE
Ring in the new year:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,9 +38,9 @@ jobs:
     strategy:
       matrix:
         resolver:
+          - lts-17
           - lts-16
           - lts-14
-          - lts-12
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ runhs (watch|repl|script|compile) <file> [<args>]
 
 ## Copyright and License
 
-Copyright Daniel Brice (c) 2020
-
-All rights reserved.
+Copyright (C) 2020-2021 Daniel Brice
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/runhs.cabal
+++ b/runhs.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name: runhs
-version: 1.0.0.8
+version: 1.0.0.9
 synopsis: Stack wrapper for single-file Haskell programs.
 description:
   Stack wrapper for single-file Haskell programs.
@@ -12,7 +12,7 @@ homepage: https://github.com/friedbrice/runhs#readme
 bug-reports: https://github.com/friedbrice/runhs/issues
 author: Daniel Brice
 maintainer: danielbrice@gmail.com
-copyright: 2020 Daniel Brice
+copyright: Copyright (C) 2020-2021 Daniel Brice
 license: BSD-3-Clause
 license-file: README.md
 build-type: Simple

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
-resolver: lts-16.9
+resolver: lts-16.12
 packages: ['.']

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -52,7 +52,7 @@ test resolver = hspec $ do
             out `shouldContain` "greet :: [String] -> [IO ()]"
             err `shouldContain` unwords ["Selected resolver:", resolver]
 
-        -- broken in CI. works on my machine. i don't have time for this shit.
+        -- broken in CI. works on my machine. i don't have time for this ****.
         -- it "should load in watch mode" $ do
         --     (_, out, err) <- runhs resolver Watch helloHaskell ["--allow-eval"] ""
         --     -- Ghcid exits with success on Windows, with error on Unix.


### PR DESCRIPTION
* drop GHC-8.4 from compat check

* add GHC-8.10 to compat check

* Update copyright in docs and cabal file

* Update resolver to lts-16.12

* show some humility in the comments